### PR TITLE
Match eir to pf model

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -72,7 +72,11 @@ vivax_equilibrium <- function(EIR, ft, p,
   
   age_bite = 1 - rho_age*exp(-age_mids/age_0)
   omega_age = 1/sum(age_demog*age_bite)
-  age_bite = omega_age*age_bite
+  ## This part standardises the population level (including age structuring) to
+  ## the initial EIR value. The Pf model does not do this, so for consistency we
+  ## are changing this to the Pf method. We do not believe this will make a 
+  ## substantial change to analytical outputs.
+  # age_bite = omega_age*age_bite
   
   ###########################################################################
   ## Heterogeneity in mosquito bites
@@ -519,7 +523,12 @@ vivax_equilibrium <- function(EIR, ft, p,
     }
   }
   
-  FOIv_eq <- sum(FOIvij_eq)
+  ## When we remove the age-standardisation from the earlier EIR calculation,
+  ## we need to instead account for this in the calculation of FOIM, 
+  ## as found in the pf model.
+  # FOIv_eq <- sum(FOIvij_eq)
+  FOIv_eq <- sum(FOIvij_eq) * omega_age
+  
   return(list(states = states_3d, FOIM = FOIv_eq))
   
 }

--- a/R/main.R
+++ b/R/main.R
@@ -75,8 +75,10 @@ vivax_equilibrium <- function(EIR, ft, p,
   ## This part standardises the population level (including age structuring) to
   ## the initial EIR value. The Pf model does not do this, so for consistency we
   ## are changing this to the Pf method. We do not believe this will make a 
-  ## substantial change to analytical outputs.
-  # age_bite = omega_age*age_bite
+  ## fundemental change to analytical outputs.
+  if(p$vivax_EIR_at_population_level){
+    age_bite = omega_age*age_bite
+  }
   
   ###########################################################################
   ## Heterogeneity in mosquito bites
@@ -526,8 +528,11 @@ vivax_equilibrium <- function(EIR, ft, p,
   ## When we remove the age-standardisation from the earlier EIR calculation,
   ## we need to instead account for this in the calculation of FOIM, 
   ## as found in the pf model.
-  # FOIv_eq <- sum(FOIvij_eq)
-  FOIv_eq <- sum(FOIvij_eq) * omega_age
+  if(p$vivax_EIR_at_population_level){
+    FOIv_eq <- sum(FOIvij_eq)
+  } else {
+    FOIv_eq <- sum(FOIvij_eq) * omega_age 
+  }
   
   return(list(states = states_3d, FOIM = FOIv_eq))
   

--- a/R/main.R
+++ b/R/main.R
@@ -76,7 +76,7 @@ vivax_equilibrium <- function(EIR, ft, p,
   ## the initial EIR value. The Pf model does not do this, so for consistency we
   ## are changing this to the Pf method. We do not believe this will make a 
   ## fundemental change to analytical outputs.
-  if(p$vivax_EIR_at_population_level){
+  if(isTRUE(p$vivax_EIR_at_population_level)){
     age_bite = omega_age*age_bite
   }
   
@@ -528,7 +528,7 @@ vivax_equilibrium <- function(EIR, ft, p,
   ## When we remove the age-standardisation from the earlier EIR calculation,
   ## we need to instead account for this in the calculation of FOIM, 
   ## as found in the pf model.
-  if(p$vivax_EIR_at_population_level){
+  if(isTRUE(p$vivax_EIR_at_population_level)){
     FOIv_eq <- sum(FOIvij_eq)
   } else {
     FOIv_eq <- sum(FOIvij_eq) * omega_age 


### PR DESCRIPTION
The Pf and Pv models use conceptually different EIR. The Pf model uses EIR at the adult level, which must factor in the age specific biting of children. The Pv model uses EIR at the population level: in assumes that this age specific biting is already included. We have standardised these to the Pf model, assuming that this will not fundamentally change the key model relationships, but have left the option to calculate and use the population level EIR instead (this carries forward into malariasimulation).